### PR TITLE
Add `quick_search_content` front matter overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,10 @@ bridgetown-search-results::part(inner-link) {
 
 ## Controlling the Search Index
 
-You can add `exclude_from_search: true` to the front matter of any page or document to exclude it from the search index JSON. To batch-exclude pages, collections, categories, etc., you could use front matter defaults to set the `exclude_from_search` variable.
+You can provide additional front matter variables to any page or document to control the search index. These are:
 
-You can add `quick_search_content: "override the default content"` to the front matter on any page or document to change the searched content from the content of the page to the content of the `quick_search_content` frontmatter variable. This is useful for fine tuning what should be found on a page, or in cases where you are [dynamically generating resources in a Resource Builder](https://www.bridgetownrb.com/docs/plugins/external-apis#the-resource-builder).
+* `exclude_from_search: true`: Setting this will exclude that item from the search index JSON. To batch-exclude pages, collections, categories, etc., you could use front matter defaults to set the `exclude_from_search` variable.
+* `quick_search_content: "content for the index"`: Setting this will override the content in the search index JSON. Normally the content in the search index JSON is the content of the page. Setting this front matter variable explicilty sets the content in the search index JSON.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ bridgetown-search-results::part(inner-link) {
 
 You can add `exclude_from_search: true` to the front matter of any page or document to exclude it from the search index JSON. To batch-exclude pages, collections, categories, etc., you could use front matter defaults to set the `exclude_from_search` variable.
 
+You can add `quick_search_content: "override the default content"` to the front matter on any page or document to change the searched content from the content of the page to the content of the `quick_search_content` frontmatter variable. This is useful for fine tuning what should be found on a page, or in cases where you are [dynamically generating resources in a Resource Builder](https://www.bridgetownrb.com/docs/plugins/external-apis#the-resource-builder).
+
 ## Testing
 
 * Run `bundle exec rspec` to run the test suite

--- a/content/bridgetown_quick_search/index.json
+++ b/content/bridgetown_quick_search/index.json
@@ -10,6 +10,8 @@ exclude_from_search: true
     {%- if document.title %}
       {%- unless document.exclude_from_search or document.id == "" %}
         {%- assign url = document.url %}
+        {%- assign content = document.content %}
+        {%- if document.quick_search_content %}{% assign content = document.quick_search_content %}{% endif %}
         {%- if site.content_engine == "resource" %}{% assign url = document.relative_url %}{% endif %}
         {%- if looped %},{% endif %}
         {
@@ -24,7 +26,7 @@ exclude_from_search: true
           "categories": {{ document.categories | join: ", " | jsonify }},
           "tags": {{ document.tags | join: ", " | jsonify }},
           "url": {{ url | jsonify }},
-          "content": {{ document.content | strip_html | replace_regex: "[\s/\n]+"," " | strip | jsonify }}
+          "content": {{ content | strip_html | replace_regex: "[\s/\n]+"," " | strip | jsonify }}
         }
         {%- assign looped = true %}
       {%- endunless %}
@@ -35,13 +37,15 @@ exclude_from_search: true
       {%- if document.title %}
         {%- unless document.exclude_from_search %}
           {%- if looped %},{% endif %}
+          {%- assign content = document.content %}
+          {%- if document.quick_search_content %}{% assign content = document.quick_search_content %}{% endif %}
           {
             "id": "{{ document.url | slugify }}",
             "title": {{ document.title | jsonify }},
             "categories": {{ document.categories | join: ", " | jsonify }},
             "tags": {{ document.tags | join: ", " | jsonify }},
             "url": {{ document.url | jsonify }},
-            "content": {{ document.content | strip_html | replace_regex: "[\s/\n]+"," " | strip | jsonify }}
+            "content": {{ content | strip_html | replace_regex: "[\s/\n]+"," " | strip | jsonify }}
           }
         {%- endunless %}
       {%- endif %}

--- a/content/bridgetown_quick_search/index.json
+++ b/content/bridgetown_quick_search/index.json
@@ -1,5 +1,6 @@
 ---
 template_engine: liquid
+exclude_from_search: true
 ---
 [
   {%- assign looped = false %}

--- a/spec/bridgetown-quick-search_spec.rb
+++ b/spec/bridgetown-quick-search_spec.rb
@@ -77,6 +77,22 @@ describe(Bridgetown::QuickSearch) do
       end
     end
 
+    context "based upon quick_search_terms" do
+      let(:terms_entry) {
+        parsed_index.find { |entry| entry["url"] == "/terms/" }
+      }
+
+      it "creates the index.json file" do
+        expect(index_json).to exist
+      end
+
+      it "includes contente from quick_search_terms" do
+        expect(terms_entry["content"]).to match(/quick terms/)
+      end
+
+      it "does not include content from quick_search_terms body" do
+        expect(terms_entry["content"]).not_to match(/NOT IN SEARCH/)
+      end
     end
   end
 end

--- a/spec/bridgetown-quick-search_spec.rb
+++ b/spec/bridgetown-quick-search_spec.rb
@@ -2,34 +2,66 @@
 
 require "spec_helper"
 
+# I am not sure why this is necessary, but it is the only way that the
+# initializer is actuall still run on every example, if the config is left in
+# the `let` then the initializer is only run on the first example
+module TestValues
+  class << self
+    attr_accessor :config
+  end
+end
+
+
 describe(Bridgetown::QuickSearch) do
-  let(:overrides) { {} }
   let(:config) do
-    Bridgetown.configuration(Bridgetown::Utils.deep_merge_hashes({
+    TestValues::config ||= Bridgetown.configuration(Bridgetown::Utils.deep_merge_hashes({
       "full_rebuild" => true,
       "root_dir"     => root_dir,
       "source"       => source_dir,
       "destination"  => dest_dir,
-    }, overrides))
-  end
-  let(:metadata_overrides) { {} }
-  let(:metadata_defaults) do
-    {
-      "name" => "My Awesome Site",
-      "author" => {
-        "name" => "Ada Lovejoy",
-      }
-    }
-  end
-  let(:site) { Bridgetown::Site.new(config) }
-  let(:contents) { File.read(dest_dir("index.html")) }
-  before(:each) do
-    metadata = metadata_defaults.merge(metadata_overrides).to_yaml.sub("---\n", "")
-    File.write(source_dir("_data/site_metadata.yml"), metadata)
-    site.process
-    FileUtils.rm(source_dir("_data/site_metadata.yml"))
+    }, overrides)).tap do |conf|
+      conf.run_initializers! context: :static
+    end
   end
 
-  it "doesn't have tests yet" do
+  describe "plugin behavior" do
+    let(:overrides) { {} }
+    let(:metadata_overrides) { {} }
+    let(:metadata_defaults) do
+      {
+        "name" => "My Awesome Site",
+        "author" => {
+          "name" => "Ada Lovejoy",
+        }
+      }
+    end
+
+    let(:site) { Bridgetown::Site.new(config) }
+    let(:contents) { File.read(dest_dir("index.html")) }
+    let(:index_json) { Pathname.new(dest_dir("bridgetown_quick_search/index.json")) }
+
+    before(:each) do
+      metadata = metadata_defaults.merge(metadata_overrides).to_yaml.sub("---\n", "")
+      File.write(source_dir("_data/site_metadata.yml"), metadata)
+      site.process
+      FileUtils.rm(source_dir("_data/site_metadata.yml"))
+    end
+
+    context "based upon page contents" do
+      it "creates the index.html file" do
+        expect(contents).to match 'Testing this plugin'
+      end
+
+      it "creates the index.json file" do
+        expect(index_json).to exist
+      end
+
+      it "has the content from the index.html file in the index" do
+        expect(index_json).to exist
+        parsed_index = JSON.parse(index_json.read)
+        root_entry = parsed_index.find { |entry| entry["url"] == "/" }
+        expect(root_entry).not_to be_nil
+        expect(root_entry["content"]).to match(/Testing this plugin/)
+      end
   end
 end

--- a/spec/bridgetown-quick-search_spec.rb
+++ b/spec/bridgetown-quick-search_spec.rb
@@ -40,6 +40,10 @@ describe(Bridgetown::QuickSearch) do
     let(:contents) { File.read(dest_dir("index.html")) }
     let(:index_json) { Pathname.new(dest_dir("bridgetown_quick_search/index.json")) }
 
+    def parsed_index(index: index_json)
+      JSON.parse(index.read)
+    end
+
     before(:each) do
       metadata = metadata_defaults.merge(metadata_overrides).to_yaml.sub("---\n", "")
       File.write(source_dir("_data/site_metadata.yml"), metadata)
@@ -57,16 +61,12 @@ describe(Bridgetown::QuickSearch) do
       end
 
       it "has the content from the index.html file in the index" do
-        expect(index_json).to exist
-        parsed_index = JSON.parse(index_json.read)
         root_entry = parsed_index.find { |entry| entry["url"] == "/" }
         expect(root_entry).not_to be_nil
         expect(root_entry["content"]).to match(/Testing this plugin/)
       end
 
       it "does not include its own template in the output" do
-        expect(index_json).to exist
-        parsed_index = JSON.parse(index_json.read)
         index_entry  = parsed_index.find { |entry| entry["url"] == "/bridgetown_quick_search/index.json" }
         expect(index_entry).to be_nil
       end

--- a/spec/bridgetown-quick-search_spec.rb
+++ b/spec/bridgetown-quick-search_spec.rb
@@ -63,5 +63,13 @@ describe(Bridgetown::QuickSearch) do
         expect(root_entry).not_to be_nil
         expect(root_entry["content"]).to match(/Testing this plugin/)
       end
+
+      it "does not include its own template in the output" do
+        expect(index_json).to exist
+        parsed_index = JSON.parse(index_json.read)
+        index_entry  = parsed_index.find { |entry| entry["url"] == "/bridgetown_quick_search/index.json" }
+        expect(index_entry).to be_nil
+      end
+    end
   end
 end

--- a/spec/bridgetown-quick-search_spec.rb
+++ b/spec/bridgetown-quick-search_spec.rb
@@ -70,6 +70,13 @@ describe(Bridgetown::QuickSearch) do
         index_entry  = parsed_index.find { |entry| entry["url"] == "/bridgetown_quick_search/index.json" }
         expect(index_entry).to be_nil
       end
+
+      it "does not include excluded content" do
+        excluded_entry = parsed_index.find { |entry| entry["url"] == "/excluded/" }
+        expect(excluded_entry).to be_nil
+      end
+    end
+
     end
   end
 end

--- a/spec/bridgetown-quick-search_spec.rb
+++ b/spec/bridgetown-quick-search_spec.rb
@@ -86,8 +86,8 @@ describe(Bridgetown::QuickSearch) do
         expect(index_json).to exist
       end
 
-      it "includes contente from quick_search_terms" do
-        expect(terms_entry["content"]).to match(/quick terms/)
+      it "includes content from quick_search_terms" do
+        expect(terms_entry["content"]).to match(/override the default content/)
       end
 
       it "does not include content from quick_search_terms body" do

--- a/spec/fixtures/config/initializers.rb
+++ b/spec/fixtures/config/initializers.rb
@@ -1,0 +1,5 @@
+# frozen_string_literals: true
+
+Bridgetown.configure do
+  init :"bridgetown-quick-search"
+end

--- a/spec/fixtures/src/excluded.html
+++ b/spec/fixtures/src/excluded.html
@@ -1,0 +1,5 @@
+---
+exclude_from_search: true
+---
+
+excluded

--- a/spec/fixtures/src/terms.html
+++ b/spec/fixtures/src/terms.html
@@ -1,5 +1,5 @@
 ---
-quick_search_terms: "quick terms"
+quick_search_content: "override the default content"
 ---
 
 NOT IN SEARCH

--- a/spec/fixtures/src/terms.html
+++ b/spec/fixtures/src/terms.html
@@ -1,0 +1,5 @@
+---
+quick_search_terms: "quick terms"
+---
+
+NOT IN SEARCH


### PR DESCRIPTION
As was discussed in https://github.com/bridgetownrb/bridgetown/discussions/743 - this is a PR that provides a quick search content override front matter variable.

From the updated README:

* `quick_search_content: "content for the index"`: Setting this will override the content in the search index JSON. Normally the content in the search index JSON is the content of the page. Setting this front matter variable explicilty sets the content in the search index JSON.

This PR also added tests coverage for the existing functionality as the existing tests were just stubs, and fixes a bug where the `index.json` template itself included in the search index.
