### PR TITLE
feature: add all frontmatter data to search index

### DIFF
--- a/content/bridgetown_quick_search/index.json
+++ b/content/bridgetown_quick_search/index.json
@@ -23,7 +23,8 @@ template_engine: liquid
           "categories": {{ document.categories | join: ", " | jsonify }},
           "tags": {{ document.tags | join: ", " | jsonify }},
           "url": {{ url | jsonify }},
-          "content": {{ document.content | strip_html | replace_regex: "[\s/\n]+"," " | strip | jsonify }}
+          "content": {{ document.content | strip_html | replace_regex: "[\s/\n]+"," " | strip | jsonify }},
+          "data": {{ document.data | jsonify }}
         }
         {%- assign looped = true %}
       {%- endunless %}
@@ -40,7 +41,8 @@ template_engine: liquid
             "categories": {{ document.categories | join: ", " | jsonify }},
             "tags": {{ document.tags | join: ", " | jsonify }},
             "url": {{ document.url | jsonify }},
-            "content": {{ document.content | strip_html | replace_regex: "[\s/\n]+"," " | strip | jsonify }}
+            "content": {{ document.content | strip_html | replace_regex: "[\s/\n]+"," " | strip | jsonify }},
+            "data": {{ document.data | jsonify }}
           }
         {%- endunless %}
       {%- endif %}


### PR DESCRIPTION
## Why?

Because the `lunr` search engine does not guarantee order. By passing along all frontmatter, you could sort your posts by something like "date" for example when you query for all your posts, you may want to sort by "date"

## Other key considered

`"frontmatter"` instead of "data", but "data" felt like it was more aligned with `document.data`