### PR TITLE
feat: add collection name to preview title

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,12 @@ You can provide additional Liquid variables to the component to configure its ap
 * `input_class`: Add custom CSS class names to the input control
 * `theme`: The component's default theme is a "light" appearance, but you can also set it to use a "dark" appearance
 * `snippet_length`: The length of the text snippet for each search result. Defaults to 142.
+* `display_collection`: Will show collections to which belong search results if true. Defaults to false.
 
 Here's an example of using all variables at once:
 
 ```html
-{% render "bridgetown_quick_search/search", placeholder: "Search", input_class: "input", theme: "dark", snippet_length: 200 %}
+{% render "bridgetown_quick_search/search", placeholder: "Search", input_class: "input", theme: "dark", snippet_length: 200, display_collection: true %}
 ```
 
 ## Styling

--- a/components/bridgetown_quick_search/search.liquid
+++ b/components/bridgetown_quick_search/search.liquid
@@ -4,8 +4,9 @@ variables:
   placeholder?: [string, Placeholder text for the search input control.]
   theme: [string, Dark or Light theme ("dark" or "light"). Defaults to light.]
   snippet_length?: [integer, Length of the result text snippet. Defaults to 142.] 
+  display_collection?: [boolean, Displays the collection name. Defaults to false.]
 {% endcomment %}
 <bridgetown-search-form>
   <input slot="input" type="search" class="{{ input_class }}" placeholder="{{ placeholder }}" />
-  <bridgetown-search-results {% if snippet_length %}snippetlength="{{ snippet_length }}" {% endif %}theme="{% if theme %}{{ theme }}{% endif %}"></bridgetown-search-results>
+  <bridgetown-search-results {% if snippet_length %}snippetlength="{{ snippet_length }}" {% endif %}theme="{% if theme %}{{ theme }} {% endif %}"{% if display_collection %}displayCollection="{{ display_collection }}"{% endif %}></bridgetown-search-results>
 </bridgetown-search-form>

--- a/frontend/javascript/index.js
+++ b/frontend/javascript/index.js
@@ -44,6 +44,7 @@ export class BridgetownSearchResults extends LitElement {
   @property({ type: String }) theme
   @property({ type: Array }) results = []
   @property({ type: Number }) snippetLength = 142
+  @property({ type: Boolean }) displayCollection = false
 
   static styles = css`
     :host {
@@ -162,7 +163,7 @@ export class BridgetownSearchResults extends LitElement {
     this.latestQuery = query
     if (query && query.length > 1) {
       this.showResults = true
-      this.results = this.searchEngine.performSearch(query, this.snippetLength).slice(0, 10)
+      this.results = this.searchEngine.performSearch(query, this.snippetLength, this.displayCollection).slice(0, 10)
     } else {
       this.showResults = false
     }

--- a/frontend/javascript/search_engine.js
+++ b/frontend/javascript/search_engine.js
@@ -21,7 +21,7 @@ class SearchEngine {
     this.indexData = indexData
   }
 
-  performSearch(query, snippetLength = null) {
+  performSearch(query, snippetLength = null, displayCollection = false) {
     if (this.index) {
       this.query = query
       const results = this.index.search(this.query)
@@ -30,7 +30,8 @@ class SearchEngine {
         return results.map(result => {
           const item = this.indexData.find(item => item.id == result.ref)
           const contentPreview = this.previewTemplate(item.content, snippetLength)
-          const titlePreview = this.previewTemplate(item.title) + `<!--(${result.score})-->`
+          const collectionName = displayCollection ? `${item.collection.name} > ` : ""
+          const titlePreview = collectionName + this.previewTemplate(item.title) + `<!--(${result.score})-->`
 
           return {
             url: item.url.trim(),


### PR DESCRIPTION
It could be nice to be able to identify from which collection comes a result preview so I thought it would be the perfect occasion to contribute.

This adds the `display_collection` option which defaults to `false`, let me know what can be improved!

<img width="552" alt="image" src="https://github.com/bridgetownrb/bridgetown-quick-search/assets/1301085/126f9faa-e4fe-404c-95ef-049215cc0ad9">
